### PR TITLE
Patch road pricing for caps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ matsimExamples
 
 # ignore output directories:
 output/
+
+contribs/noise/nullaverage_damages_link/
+contribs/noise/nullaverage_damages_link_car/
+contribs/noise/nullaverage_damages_link_hgv/
+contribs/noise/nulldamages_receiverPoint/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Arup CML's Fork of MATSim
+
+This is a local fork of the MATSim code base. We intend to make as few local changes to MATSim as we possibly can, but
+every once in a while there will be something that we want or need to change that is not appropriate to push to
+"MATSim central". These Arup-specific changes are handled here.
+
+Initially we created this fork in order to make some changes to the road pricing extension, as described in the
+[README of that subproject](contribs/roadpricing/README.md). We should use that as a template for making future
+changes to specific modules, for example if we want to do something with the EV or emissions modules.
+---
+
 ## Overview
 
 MATSim provides a toolbox to run and implement large-scale agent-based

--- a/contribs/roadpricing/README.md
+++ b/contribs/roadpricing/README.md
@@ -1,15 +1,56 @@
 
-# Road pricing
+# Road Pricing
 
 This package provides functionality to simulate different road-pricing scenarios in MATSim. 
 
 It provides support for different toll schemes, for example distance tolls, cordon tolls and area tolls. 
 The toll schemes are described in special XML files (see below).
 
-All supported toll schemes can be limited to a part of the network and can be time-dependent (that means that the amount agents have to pay for the toll can differ during the simulated day).
+All supported toll schemes can be limited to a part of the network and can be time-dependent (that means that the amount
+agents have to pay for the toll can differ during the simulated day).
 
-The specified toll amount should be in respect to the scoring function used. Typically, the scoring function contains a parameter that defines the marginal utility of money; that parameter is used to convert toll amounts into utilities.
+The specified toll amount should be in respect to the scoring function used. Typically, the scoring function contains a
+parameter that defines the marginal utility of money; that parameter is used to convert toll amounts into utilities.
 
-For more informations, please consult the [javadoc.](http://ci.matsim.org:8080/job/MATSim_contrib_M2/org.matsim.contrib$roadpricing/javadoc/?) 
+For more informations, please consult the
+[javadoc.](http://ci.matsim.org:8080/job/MATSim_contrib_M2/org.matsim.contrib$roadpricing/javadoc/?)
 
+# Arup CML Fork
+
+We forked `matsim-libs` initially to make some small changes to this road pricing module, as discussed in this
+[issue on MATSim central](https://github.com/matsim-org/matsim-libs/issues/1898). Given that we are currently only
+making changes in this module, I have modified the `contribs/roadpricing/pom.xml` so that building this module now
+produces a Maven artefact in `contribs/roadpricing/target/` called `arup-roadpricing-14.0-SNAPSHOT.jar`, to
+differentiate it from the version from MATSim central. If all you are doing is making changes to this road pricing
+module and nothing else, you can build the jar file independently of the rest of the MATSim project - this will be
+*much* quicker than running a full MATSim build:
+
+```bash
+cd contribs/roadpricing/
+mvn clean package
+
+...
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD SUCCESS
+[INFO] ------------------------------------------------------------------------
+[INFO] Total time: 39.725 s
+[INFO] Finished at: 2022-03-11T13:01:32Z
+[INFO] Final Memory: 31M/117M
+[INFO] ------------------------------------------------------------------------
+
+ls -talh target/
+
+total 208
+drwxr-xr-x   9 mickyfitz  staff   288B 11 Mar 13:02 ..
+-rw-r--r--   1 mickyfitz  staff    42K 11 Mar 13:01 arup-roadpricing-14.0-SNAPSHOT-sources.jar
+drwxr-xr-x  11 mickyfitz  staff   352B 11 Mar 13:01 .
+-rw-r--r--   1 mickyfitz  staff    57K 11 Mar 13:01 arup-roadpricing-14.0-SNAPSHOT.jar
+drwxr-xr-x   3 mickyfitz  staff    96B 11 Mar 13:01 maven-archiver
+drwxr-xr-x  18 mickyfitz  staff   576B 11 Mar 13:01 surefire-reports
+drwxr-xr-x   3 mickyfitz  staff    96B 11 Mar 13:00 test-classes
+drwxr-xr-x   3 mickyfitz  staff    96B 11 Mar 13:00 generated-test-sources
+drwxr-xr-x   3 mickyfitz  staff    96B 11 Mar 13:00 generated-sources
+drwxr-xr-x   3 mickyfitz  staff    96B 11 Mar 13:00 maven-status
+drwxr-xr-x   4 mickyfitz  staff   128B 11 Mar 13:00 classes
+```
  

--- a/contribs/roadpricing/pom.xml
+++ b/contribs/roadpricing/pom.xml
@@ -5,9 +5,9 @@
 		<version>14.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.matsim.contrib</groupId>
-	<artifactId>roadpricing</artifactId>
-	<name>roadpricing</name>
+	<groupId>com.arup.cml</groupId>
+	<artifactId>arup-roadpricing</artifactId>
+	<name>arup-roadpricing</name>
 	<build>
 		<resources>
 			<resource>

--- a/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingControlerListener.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingControlerListener.java
@@ -64,10 +64,13 @@ class RoadPricingControlerListener implements StartupListener, IterationEndsList
 	private final OutputDirectoryHierarchy controlerIO;
 
 	@Inject
-	RoadPricingControlerListener( RoadPricingScheme scheme, Network network,
-				      EventsManager events, OutputDirectoryHierarchy controlerIO ) {
+	RoadPricingControlerListener( RoadPricingScheme scheme,
+								  Network network,
+								  EventsManager events,
+								  RoadPricingTollCalculator roadPricingTollCalculator,
+								  OutputDirectoryHierarchy controlerIO ) {
 		this.scheme = scheme;
-		this.calcPaidToll = new RoadPricingTollCalculator( network, scheme, events );
+		this.calcPaidToll = roadPricingTollCalculator;
 		this.cattl = new CalcAverageTolledTripLength( network, scheme, events );
 		this.controlerIO = controlerIO;
 		Gbl.printBuildInfo("RoadPricing", "/org.matsim.contrib/roadpricing/revision.txt");

--- a/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingModule.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingModule.java
@@ -56,6 +56,6 @@ public final class RoadPricingModule extends AbstractModule {
 
 		// this is what makes the mobsim compute tolls and generate money events
 		addControlerListenerBinding().to(RoadPricingControlerListener.class);
-		
+		bind(RoadPricingTollCalculator.class).in(Singleton.class);
 	}
 }

--- a/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingTollCalculator.java
+++ b/contribs/roadpricing/src/main/java/org/matsim/contrib/roadpricing/RoadPricingTollCalculator.java
@@ -78,6 +78,7 @@ public final class RoadPricingTollCalculator implements LinkEnterEventHandler, V
 	private final TollBehaviourI handler;
 	private final Vehicle2DriverEventHandler delegate = new Vehicle2DriverEventHandler();
 
+	@Inject
 	RoadPricingTollCalculator(final Network network, final RoadPricingScheme scheme, EventsManager events ) {
 		super();
 		events.addHandler(this);
@@ -151,20 +152,20 @@ public final class RoadPricingTollCalculator implements LinkEnterEventHandler, V
 	}
 
 
-//	/**
-//	 * Returns the toll the specified agent has paid in the course of the
-//	 * simulation so far.
-//	 *
-//	 * @param agentId
-//	 * @return The toll paid by the specified agent, 0.0 if no toll was paid.
-//	 */
-//	double getAgentToll(final Id<Person> agentId) {
-//		AgentTollInfo info = this.agents.get(agentId);
-//		if (info == null) {
-//			return 0.0;
-//		}
-//		return info.toll;
-//	}
+	/**
+	 * Returns the toll the specified agent has paid in the course of the
+	 * simulation so far.
+	 *
+	 * @param agentId
+	 * @return The toll paid by the specified agent, 0.0 if no toll was paid.
+	 */
+	public double getAgentToll(final Id<Person> agentId) {
+		AgentTollInfo info = this.agents.get(agentId);
+		if (info == null) {
+			return 0.0;
+		}
+		return info.toll;
+	}
 
 	/**
 	 * @return The toll paid by all the agents.


### PR DESCRIPTION
These are the changes to MATSim's road pricing module that allow us to make the necessary changes to the `CappedTollFactor` class in Columbus so that we fix the "cap leak" bug (PR for those upcoming). 

There is a fair amount of discussion about the motivation for these changes on [this issue I created on MATSim central](https://github.com/matsim-org/matsim-libs/issues/1898).

I've added most of you just so you know that this fork exists, but feel free to review the changes if you want. Although @gac55 and @akay-arup - one of you should review this.

In addition to building the roadpricing module, which has some unit tests and takes around 35 seconds, I also successfully ran the full MATSim build locally, which takes over an hour :/

<img width="580" alt="arup-matsim-libs-roadpricing-build" src="https://user-images.githubusercontent.com/250899/158067894-16ffbdf4-5f85-405c-b6c4-f082338230c5.png">
